### PR TITLE
Adicionado shortcode na página de cursos

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -84,6 +84,54 @@ button:hover {
     box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
 }
 
+/* Estilos para os palestrantes */
+
+.instrutor-bloco {
+    display: flex;
+    flex-direction: row;
+    background: #fff;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    padding-inline: 3rem;
+    padding-top: 1rem;
+    padding-bottom: 0.3rem;
+
+    margin: 20px auto; /* margens automáticas para centralizar */
+    border-radius: 8px;
+    align-items: center;
+    gap: 20px;
+    max-width: 1000px; /* limite na largura */
+    width: 90%; /* para responsividade */
+}
+
+.instrutor-imagem img {
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 50%; /* deixa redonda */
+    margin-bottom: 0;
+}
+
+.instrutor-info {
+    flex: 1;
+    min-width: 200px;
+}
+
+.instrutor-info h2 {
+    margin: 0;
+}
+
+
+@media (max-width: 768px) {
+    .instrutor-bloco {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .instrutor-imagem img {
+        width: 120px;
+        height: 120px;
+    }
+}
 
 @media (max-width: 605px) {
     .nav-menu {

--- a/functions.php
+++ b/functions.php
@@ -264,7 +264,7 @@ function registrar_cpt_cursos()
     $args = array(
         'labels'             => $labels,
         'public'             => true,
-        'show_in_rest'       => false,
+        'show_in_rest'       => true,
         'has_archive'        => true,
         'menu_position'      => 5,
         'menu_icon'          => 'dashicons-welcome-learn-more',
@@ -413,6 +413,43 @@ function membros_shortcode($atts) {
     return $output;
 }
 add_shortcode('membros', 'membros_shortcode');
+
+// Shortcode para instrutores nas páginas de cursos
+
+function instrutor_shortcode($atts, $content = null) {
+    // Define os atributos com valores padrão
+    $atts = shortcode_atts(array(
+        'nome' => 'Nome do Instrutor',
+        'imagem' => '', // URL ou nome da imagem na biblioteca
+        'descricao' => ''
+    ), $atts, 'instrutor');
+
+    // Se for o nome de uma imagem da biblioteca, pega a URL
+    if (!filter_var($atts['imagem'], FILTER_VALIDATE_URL)) {
+        $img = get_page_by_title($atts['imagem'], OBJECT, 'attachment');
+        if ($img) {
+            $atts['imagem'] = wp_get_attachment_url($img->ID);
+        }
+    }
+
+    // HTML do bloco
+    ob_start();
+    ?>
+    <div class="instrutor-bloco">
+        <?php if ($atts['imagem']) : ?>
+            <div class="instrutor-imagem">
+                <img src="<?php echo esc_url($atts['imagem']); ?>" alt="<?php echo esc_attr($atts['nome']); ?>">
+            </div>
+        <?php endif; ?>
+        <div class="instrutor-info">
+            <h2><?php echo esc_html($atts['nome']); ?></h2>
+            <p><?php echo esc_html($atts['descricao']); ?></p>
+        </div>
+    </div>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode('instrutor', 'instrutor_shortcode');
 
 // Função auxiliar para verificar se um membro é formado na página de membros
 


### PR DESCRIPTION
## O que foi feito
- Criado um shortcode [palestrante] para inserção de instrutores nas páginas de cursos.
- Estilização responsiva: bloco com imagem redonda, sombra e alinhamento centralizado.

## Motivo
Facilitar a adição manual de palestrantes/instrutores sem precisar mexer diretamente no código.

## Observações
- CSS adicionado no arquivo `main.css`.
- Shortcode implementado no `functions.php`.
- Bloco limitado a `max-width: 1000px` para melhor apresentação em telas grandes.